### PR TITLE
Specify stale time for cabins and user query

### DIFF
--- a/src/features/authentication/__tests__/ProtectedRoute.test.tsx
+++ b/src/features/authentication/__tests__/ProtectedRoute.test.tsx
@@ -42,8 +42,8 @@ afterEach(() => {
 
 describe('ProtectedRoute', () => {
 	it('should redirect user to login page if user session does not exist', async () => {
-		setup();
 		vi.spyOn(supabase.auth, 'getSession').mockResolvedValueOnce(nonExistentSession);
+		setup();
 
 		const loginForm = await screen.findByRole('form');
 

--- a/src/features/authentication/__tests__/ProtectedRoute.test.tsx
+++ b/src/features/authentication/__tests__/ProtectedRoute.test.tsx
@@ -1,6 +1,7 @@
 import { renderWithQueryClient } from '@/test/utils';
 import { screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
 import ProtectedRoute from '../ProtectedRoute';
 import AppLayout from '@/ui/layout/AppLayout';
 import supabase from '@/services/supabase';
@@ -50,8 +51,8 @@ describe('ProtectedRoute', () => {
 	});
 
 	it('should allow an authenticated user to access a protected route', async () => {
-		setup();
 		vi.spyOn(supabase.auth, 'getSession').mockResolvedValueOnce(userSession);
+		setup();
 
 		const dashboardTitle = await screen.findByRole('heading', { name: /dashboard/i });
 

--- a/src/features/authentication/hooks/useLogin.ts
+++ b/src/features/authentication/hooks/useLogin.ts
@@ -1,15 +1,21 @@
-import { login } from '@/services/apiAuth';
-import { AuthError } from '@supabase/supabase-js';
-import { useMutation } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+
+import { login } from '@/services/apiAuth';
+import { USER_QUERY_KEY } from '@/utils/constants';
+import { AuthError } from '@supabase/supabase-js';
 
 export function useLogin() {
 	const navigate = useNavigate();
+	const queryClient = useQueryClient();
 
 	const loginMutation = useMutation({
 		mutationFn: login,
-		onSuccess: () => navigate('/dashboard', { replace: true }),
+		onSuccess: async () => {
+			queryClient.invalidateQueries({ queryKey: [USER_QUERY_KEY] });
+			navigate('/dashboard', { replace: true });
+		},
 		onError: (error: AuthError) => {
 			toast.error(error.message);
 		},

--- a/src/features/authentication/hooks/useSignup.ts
+++ b/src/features/authentication/hooks/useSignup.ts
@@ -1,14 +1,20 @@
-import { signup } from '@/services/apiAuth';
-import { AuthError } from '@supabase/supabase-js';
-import { useMutation } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+
+import { signup } from '@/services/apiAuth';
+import { USER_QUERY_KEY } from '@/utils/constants';
+import { AuthError } from '@supabase/supabase-js';
 
 export function useSignup() {
 	const navigate = useNavigate();
+	const queryClient = useQueryClient();
 	const signupMutation = useMutation({
 		mutationFn: signup,
-		onSuccess: () => navigate('/dashboard', { replace: true }),
+		onSuccess: async () => {
+			queryClient.invalidateQueries({ queryKey: [USER_QUERY_KEY] });
+			navigate('/dashboard', { replace: true });
+		},
 		onError: (error: AuthError) => toast.error(error.message),
 	});
 

--- a/src/features/authentication/hooks/useUser.ts
+++ b/src/features/authentication/hooks/useUser.ts
@@ -8,6 +8,7 @@ export function useUser() {
 		queryKey: [USER_QUERY_KEY],
 		queryFn: getCurrentUser,
 		staleTime: ACCESS_TOKEN_EXPIRATION_TIME,
+		cacheTime: ACCESS_TOKEN_EXPIRATION_TIME + 5 * 60 * 1000,
 	});
 	return result;
 }

--- a/src/features/authentication/hooks/useUser.ts
+++ b/src/features/authentication/hooks/useUser.ts
@@ -1,8 +1,13 @@
-import { getCurrentUser } from '@/services/apiAuth';
-import { USER_QUERY_KEY } from '@/utils/constants';
 import { useQuery } from '@tanstack/react-query';
 
+import { getCurrentUser } from '@/services/apiAuth';
+import { ACCESS_TOKEN_EXPIRATION_TIME, USER_QUERY_KEY } from '@/utils/constants';
+
 export function useUser() {
-	const result = useQuery({ queryKey: [USER_QUERY_KEY], queryFn: getCurrentUser });
+	const result = useQuery({
+		queryKey: [USER_QUERY_KEY],
+		queryFn: getCurrentUser,
+		staleTime: ACCESS_TOKEN_EXPIRATION_TIME,
+	});
 	return result;
 }

--- a/src/features/cabins/hooks/useCabins.ts
+++ b/src/features/cabins/hooks/useCabins.ts
@@ -6,5 +6,6 @@ export function useCabins(userId: string | null | undefined) {
 	return useQuery({
 		queryKey: [CABINS_QUERY_KEY, userId],
 		queryFn: () => getCabins(userId),
+		staleTime: Infinity,
 	});
 }

--- a/src/features/cabins/hooks/useCabins.ts
+++ b/src/features/cabins/hooks/useCabins.ts
@@ -7,5 +7,6 @@ export function useCabins(userId: string | null | undefined) {
 		queryKey: [CABINS_QUERY_KEY, userId],
 		queryFn: () => getCabins(userId),
 		staleTime: Infinity,
+		cacheTime: Infinity,
 	});
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,8 @@
 export const MIN_PASSWORD_LENGTH = 6;
 export const MIN_FULL_NAME_LENGTH = 3;
 export const USER_QUERY_KEY = 'user';
+// In milliseconds
+export const ACCESS_TOKEN_EXPIRATION_TIME = 1 * 60 * 60 * 1000;
 
 export const CABINS_QUERY_KEY = 'cabins';
 export const CABINS_BASE_URL = `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/cabin`;


### PR DESCRIPTION
It is not necessary to instantly mark cabin and user data stale and keep fetching them frequently since they are tied to a single user, and therefore, they are unlikely to change frequently. Cabin data will change only if the logged in user creates, updates, or deletes a cabin. User session data will change when a user logs in, signs up, or when the access token expires and a new one needs to be fetched.