### PR TITLE
Add modal component

### DIFF
--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,39 @@
+import { getFocusableElements } from '@/utils/helpers';
+import { useEffect, useRef } from 'react';
+
+export default function useFocusTrap<T extends HTMLElement>() {
+	const elementRef = useRef<T>(null);
+
+	useEffect(() => {
+		if (!elementRef.current) return;
+
+		const element = elementRef.current;
+
+		const focusableElements = getFocusableElements(element);
+
+		const firstFocusableElement = focusableElements[0];
+		const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+		function handleTabKeypress(e: KeyboardEvent) {
+			if (e.key !== 'Tab') return;
+
+			// Shift + Tab was pressed and focus is on the first element -> move focus to the last element
+			if (e.shiftKey && document.activeElement === firstFocusableElement) {
+				lastFocusableElement.focus();
+				e.preventDefault();
+				// Tab was pressed and focus is on the last element -> move focus to the first element
+			} else if (!e.shiftKey && document.activeElement === lastFocusableElement) {
+				firstFocusableElement.focus();
+				e.preventDefault();
+			}
+		}
+
+		element.addEventListener('keydown', handleTabKeypress);
+
+		return () => {
+			element.removeEventListener('keydown', handleTabKeypress);
+		};
+	}, []);
+
+	return elementRef;
+}

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,40 @@
+import { isFocusable } from '@/utils/helpers';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export default function useModal() {
+	const [shouldShowModal, setShouldShowModal] = useState(false);
+	const modalTriggerElementRef = useRef<HTMLElement | null>(null);
+
+	function restoreFocus(element: HTMLElement) {
+		element.focus();
+	}
+
+	function openModal() {
+		if (isFocusable(document.activeElement)) {
+			modalTriggerElementRef.current = document.activeElement;
+		}
+		setShouldShowModal(true);
+	}
+
+	const closeModal = useCallback(() => {
+		if (modalTriggerElementRef.current) {
+			restoreFocus(modalTriggerElementRef.current);
+		}
+		setShouldShowModal(false);
+	}, []);
+
+	useEffect(() => {
+		function handleEscapeKeypress(e: KeyboardEvent) {
+			if (e.key !== 'Escape') return;
+			closeModal();
+		}
+
+		document.addEventListener('keydown', handleEscapeKeypress);
+
+		return () => {
+			document.removeEventListener('keydown', handleEscapeKeypress);
+		};
+	}, [closeModal]);
+
+	return { shouldShowModal, openModal, closeModal };
+}

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -47,7 +47,7 @@ export default createGlobalStyle`
   --fontSize-base: 1.6rem;
   --fontSize-sm: calc(var(--fontSize-base) - 0.2rem);
 
-  --backdrop-color: rgba(255, 255, 255, 0.1);
+  --backdrop-color: rgba(0, 0, 0, 0.3);
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-md: 0px 0.6rem 2.4rem rgba(0, 0, 0, 0.06);
@@ -112,12 +112,17 @@ input:disabled {
   color: var(--color-grey-500);
 }
 
-input:focus,
-button:focus,
-textarea:focus,
-select:focus {
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+:focus-visible {
   outline: 2px solid var(--color-brand-600);
   outline-offset: -1px;
+}
+
+button:focus-visible {
+  outline-offset: 3px;
 }
 
 input:not(input[type="file"]),

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -1,0 +1,114 @@
+import ReactDOM from 'react-dom';
+import styled from 'styled-components';
+import { HiXMark } from 'react-icons/hi2';
+
+import { Button } from '@/ui/button/Button';
+import { createUniqueId, getFocusableElements } from '@/utils/helpers';
+import Heading from './Heading';
+import { useEffect } from 'react';
+import useFocusTrap from '@/hooks/useFocusTrap';
+
+interface ModalProps {
+	title: string;
+	closeModal: () => void;
+	children: React.ReactNode;
+}
+
+export default function Modal({ title, closeModal, children }: ModalProps) {
+	const modalId = createUniqueId();
+	const modalRef = useFocusTrap<HTMLDivElement>();
+
+	useEffect(() => {
+		function moveFocusInsideModal() {
+			if (!modalRef.current) return;
+			const focusableElements = getFocusableElements(modalRef.current);
+			focusableElements[0].focus();
+		}
+
+		moveFocusInsideModal();
+	}, [modalRef]);
+
+	return ReactDOM.createPortal(
+		<Overlay>
+			<Container
+				id={modalId}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={`${modalId}_modalTitle`}
+				ref={modalRef}
+			>
+				<Header>
+					<Heading as="h2" id={`${modalId}_modalTitle`}>
+						{title}
+					</Heading>
+					<CloseIconButton aria-labelledby={`${modalId}_closeModalButton`} onClick={closeModal}>
+						<span className="sr-only" id={`${modalId}_closeModalButton`}>
+							Close modal
+						</span>
+						<HiXMark />
+					</CloseIconButton>
+				</Header>
+				<Body>{children}</Body>
+				<Footer>
+					<Button $variant="danger" onClick={closeModal}>
+						Close
+					</Button>
+				</Footer>
+			</Container>
+		</Overlay>,
+		document.body
+	);
+}
+
+const Overlay = styled.div`
+	--padding: 3rem;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	position: fixed;
+	top: 0;
+	left: 0;
+	padding: var(--padding);
+	width: 100%;
+	min-height: 100vh;
+	min-height: 100svh;
+	background-color: var(--backdrop-color);
+	backdrop-filter: blur(4px);
+	z-index: 1000;
+`;
+
+const Container = styled.div`
+	max-height: calc(100vh - 2 * var(--padding));
+	width: 100%;
+	max-width: 55rem;
+	padding: 3rem;
+	background-color: var(--color-grey-0);
+	border-radius: var(--border-radius-lg);
+	box-shadow: var(--shadow-lg);
+	overflow-y: auto;
+`;
+
+const Header = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+`;
+
+const Body = styled.div``;
+
+const Footer = styled.div`
+	text-align: right;
+`;
+
+const CloseIconButton = styled.button`
+	border: none;
+	padding: 0.4rem;
+	border-radius: var(--border-radius-sm);
+
+	& svg {
+		width: 2.4rem;
+		height: 2.4rem;
+		fill: var(--color-grey-500);
+	}
+`;

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -5,7 +5,7 @@ import { HiXMark } from 'react-icons/hi2';
 import { Button } from '@/ui/button/Button';
 import { createUniqueId, getFocusableElements } from '@/utils/helpers';
 import Heading from './Heading';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import useFocusTrap from '@/hooks/useFocusTrap';
 
 interface ModalProps {
@@ -28,8 +28,16 @@ export default function Modal({ title, closeModal, children }: ModalProps) {
 		moveFocusInsideModal();
 	}, [modalRef]);
 
+	function closeModalOnOverlayClick(e: React.MouseEvent) {
+		const targetElement = e.target as HTMLElement;
+
+		if (targetElement.closest(`#${modalId}`)) return;
+
+		closeModal();
+	}
+
 	return ReactDOM.createPortal(
-		<Overlay>
+		<Overlay onClick={closeModalOnOverlayClick}>
 			<Container
 				id={modalId}
 				role="dialog"

--- a/src/ui/button/Button.tsx
+++ b/src/ui/button/Button.tsx
@@ -2,8 +2,8 @@ import styled, { css } from 'styled-components';
 import { Link } from 'react-router-dom';
 
 interface ButtonProps {
-	size?: 'small' | 'medium' | 'large';
-	variant?: 'primary' | 'secondary' | 'danger';
+	$size?: 'small' | 'medium' | 'large';
+	$variant?: 'primary' | 'secondary' | 'danger';
 }
 
 const sizes = {
@@ -59,8 +59,8 @@ const commonButtonStyles = css<ButtonProps>`
 	border-radius: var(--border-radius-sm);
 	box-shadow: var(--shadow-sm);
 
-	${props => (!props.size ? sizes['medium'] : sizes[props.size])}
-	${props => (!props.variant ? variants['primary'] : variants[props.variant])}
+	${props => (!props.$size ? sizes['medium'] : sizes[props.$size])}
+	${props => (!props.$variant ? variants['primary'] : variants[props.$variant])}
 `;
 
 export const Button = styled.button<ButtonProps>`

--- a/src/ui/form/Form.tsx
+++ b/src/ui/form/Form.tsx
@@ -1,30 +1,8 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
-interface FormProps {
-	type?: 'modal';
-}
-
-const Form = styled.form<FormProps>`
-	${props =>
-		props.type !== 'modal' &&
-		css`
-			padding: 2rem;
-
-			/* Box */
-			background-color: var(--color-grey-0);
-			border: 1px solid var(--color-grey-100);
-			border-radius: var(--border-radius-md);
-		`}
-
-	${props =>
-		props.type === 'modal' &&
-		css`
-			width: 89%;
-			max-width: 80rem;
-		`}
-    
-  overflow: hidden;
-
+const Form = styled.form`
+	padding-top: 2rem;
+	padding-bottom: 2rem;
 	& > *:not(:last-child) {
 		margin-bottom: 2rem;
 	}

--- a/src/ui/layout/MainNav.tsx
+++ b/src/ui/layout/MainNav.tsx
@@ -51,6 +51,7 @@ const NavList = styled.ul`
 `;
 
 const StyledNavLink = styled(NavLink)`
+	--transition-duration: 0.2s;
 	&:link,
 	&:visited {
 		display: flex;
@@ -61,7 +62,10 @@ const StyledNavLink = styled(NavLink)`
 		font-size: 1.6rem;
 		font-weight: 600;
 		padding: 1.2rem 2.4rem;
-		transition: all 0.3s;
+		border-radius: var(--border-radius-sm);
+		transition:
+			color var(--transition-duration),
+			background-color var(--transition-duration);
 	}
 
 	/* This works because react-router places the active class on the active NavLink */
@@ -71,13 +75,12 @@ const StyledNavLink = styled(NavLink)`
 	&.active:visited {
 		color: var(--color-brand-600);
 		background-color: var(--color-brand-100);
-		border-radius: var(--border-radius-sm);
 	}
 
 	& svg {
 		width: 2.4rem;
 		height: 2.4rem;
-		transition: all 0.3s;
+		transition: color var(--transition-duration);
 	}
 
 	&:hover svg,

--- a/src/ui/layout/__tests__/Modal.test.tsx
+++ b/src/ui/layout/__tests__/Modal.test.tsx
@@ -1,0 +1,72 @@
+import Modal from '@/ui/Modal';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+const mockCloseModal = vi.fn();
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function setup() {
+	render(
+		<Modal title="This is a modal" closeModal={mockCloseModal}>
+			<p>This is some content</p>
+			<button>Some Button</button>
+		</Modal>
+	);
+}
+
+describe('Modal', () => {
+	it('should have a title, body content, and two close buttons', () => {
+		setup();
+		const modalContainer = screen.getByRole('dialog', { name: /this is a modal/i });
+		const titleElement = within(modalContainer).getByRole('heading', { name: /this is a modal/i });
+		const closeButtons = within(modalContainer).getAllByRole('button', { name: /close/i });
+		const bodyContentElement = within(modalContainer).getByText(/this is some content/i);
+
+		expect(modalContainer).toHaveAttribute('aria-modal', 'true');
+		expect(titleElement).toBeInTheDocument();
+		expect(bodyContentElement).toBeInTheDocument();
+		expect(closeButtons).toHaveLength(2);
+	});
+
+	it('should call the function to close the modal when a close button is clicked', async () => {
+		setup();
+		const user = userEvent.setup();
+		const closeButtons = screen.getAllByRole('button', { name: /close/i });
+
+		for (const closeButton of closeButtons) {
+			await user.click(closeButton);
+			expect(mockCloseModal).toBeCalled();
+		}
+	});
+
+	it('the first close button should have focus when the modal is open', () => {
+		setup();
+		const closeButtons = screen.getAllByRole('button', { name: /close/i });
+
+		expect(closeButtons[0]).toHaveFocus();
+	});
+
+	it('focus should go back to the first close button when the last close button has focus and Tab is pressed', async () => {
+		setup();
+		const user = userEvent.setup();
+		const closeButtons = screen.getAllByRole('button', { name: /close/i });
+		// Tabbing from the first close button all the way to the last close button and back to the first
+		await user.keyboard('{Tab}{Tab}{Tab}');
+
+		expect(closeButtons[0]).toHaveFocus();
+	});
+
+	it('focus should go back to the last close button when the first close button has focus and Shift + Tab is pressed', async () => {
+		setup();
+		const user = userEvent.setup();
+		const closeButtons = screen.getAllByRole('button', { name: /close/i });
+
+		await user.keyboard('{Shift>}{Tab}');
+
+		expect(closeButtons[1]).toHaveFocus();
+	});
+});

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -5,3 +5,13 @@ export function formatPrice(value: number) {
 export function createUniqueId() {
 	return Date.now().toString(36) + Math.random().toString(36).slice(2);
 }
+
+export function getFocusableElements(container: HTMLElement) {
+	return container.querySelectorAll<HTMLElement>(
+		'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), tabindex:not([tabindex="-1"])'
+	);
+}
+
+export function isFocusable(element: Element | null): element is HTMLElement {
+	return element instanceof HTMLElement;
+}


### PR DESCRIPTION
Added an accessible modal component that has the following features:

- two close buttons (an icon button in the header and a regular button in the footer)
- focus is trapped within the modal when it is open
- the icon close button is focused automatically when the modal is opened
- when the modal is closed, focus is restored to the element that triggered the modal
- apart from clicking the close buttons, the modal can be closed by pressing the Escape key or clicking the overlay