### PR TITLE
Apply max capacity settings to create and update cabin forms

### DIFF
--- a/src/features/cabins/CabinTable.tsx
+++ b/src/features/cabins/CabinTable.tsx
@@ -17,9 +17,10 @@ type Cabin = Tables<'cabin'>;
 
 interface CabinTableProps {
 	cabins: Cabin[];
+	settings: Tables<'settings'>;
 }
 
-function CabinTable({ cabins }: CabinTableProps) {
+function CabinTable({ cabins, settings }: CabinTableProps) {
 	const [selectedCabin, setSelectedCabin] = useState<null | Cabin>(null);
 	const [searchParams] = useSearchParams();
 
@@ -123,7 +124,7 @@ function CabinTable({ cabins }: CabinTableProps) {
 			</Table>
 			{selectedCabin && shouldShowUpdateModal && (
 				<Modal title="Update cabin" onCloseModal={closeUpdateModalForSelectedCabin}>
-					<UpdateCabinForm cabin={selectedCabin} onUpdate={closeUpdateModal} />
+					<UpdateCabinForm cabin={selectedCabin} settings={settings} onUpdate={closeUpdateModal} />
 				</Modal>
 			)}
 			{selectedCabin && shouldShowConfirmDeleteModal && (

--- a/src/features/cabins/UpdateCabinForm.tsx
+++ b/src/features/cabins/UpdateCabinForm.tsx
@@ -14,40 +14,46 @@ import { getModifiedFormFieldValues } from '@/utils/helpers';
 
 interface UpdateCabinFormProps {
 	cabin: Tables<'cabin'>;
+	settings: Tables<'settings'>;
 	onUpdate?: () => void;
 }
 
-const formSchema = z.object({
-	name: z
-		.string()
-		.nonempty({ message: 'Cabin name is required' })
-		.min(MIN_CABIN_NAME_LENGTH, {
-			message: `Name must contain at least ${MIN_CABIN_NAME_LENGTH} characters`,
-		}),
-	description: z.string().nonempty({ message: 'Cabin description is required' }),
-	max_capacity: z.coerce
-		.number()
-		.int({ message: 'Max capacity must be a whole number' })
-		.positive({ message: 'Max capacity must be greater than 0' }),
-	regular_price: z.coerce.number().positive({ message: 'Price must be greater than 0' }),
-	discount: z.coerce
-		.number()
-		.int({ message: 'Discount must be a whole number' })
-		.gte(0, { message: 'Discount cannot be negative' })
-		.lte(MAX_CABIN_DISCOUNT, { message: `Discount cannot be greater than ${MAX_CABIN_DISCOUNT}%` }),
-	image: z
-		.custom<FileList>()
-		.refine(files => (files.length === 0 ? true : files[0].type.startsWith('image')), {
-			message: 'File must be an image',
-		})
-		.refine(files => (files.length === 0 ? true : files[0].size <= MAX_CABIN_IMAGE_SIZE), {
-			message: `Image file size cannot exceed ${MAX_CABIN_IMAGE_SIZE / (1024 * 1024)}MB`,
-		}),
-});
+function UpdateCabinForm({ cabin, settings, onUpdate }: UpdateCabinFormProps) {
+	const formSchema = z.object({
+		name: z
+			.string()
+			.nonempty({ message: 'Cabin name is required' })
+			.min(MIN_CABIN_NAME_LENGTH, {
+				message: `Name must contain at least ${MIN_CABIN_NAME_LENGTH} characters`,
+			}),
+		description: z.string().nonempty({ message: 'Cabin description is required' }),
+		max_capacity: z.coerce
+			.number()
+			.int({ message: 'Max capacity must be a whole number' })
+			.gt(0, { message: 'Max capacity must be greater than 0' })
+			.lte(settings.max_guests_per_booking, {
+				message: `Max capacity cannot be greater than ${settings.max_guests_per_booking}`,
+			}),
+		regular_price: z.coerce.number().positive({ message: 'Price must be greater than 0' }),
+		discount: z.coerce
+			.number()
+			.int({ message: 'Discount must be a whole number' })
+			.gte(0, { message: 'Discount cannot be negative' })
+			.lte(MAX_CABIN_DISCOUNT, {
+				message: `Discount cannot be greater than ${MAX_CABIN_DISCOUNT}%`,
+			}),
+		image: z
+			.custom<FileList>()
+			.refine(files => (files.length === 0 ? true : files[0].type.startsWith('image')), {
+				message: 'File must be an image',
+			})
+			.refine(files => (files.length === 0 ? true : files[0].size <= MAX_CABIN_IMAGE_SIZE), {
+				message: `Image file size cannot exceed ${MAX_CABIN_IMAGE_SIZE / (1024 * 1024)}MB`,
+			}),
+	});
 
-type FormData = z.infer<typeof formSchema>;
+	type FormData = z.infer<typeof formSchema>;
 
-function UpdateCabinForm({ cabin, onUpdate }: UpdateCabinFormProps) {
 	const form = useForm<FormData>({
 		resolver: zodResolver(formSchema),
 

--- a/src/features/cabins/__tests__/CreateCabinForm.test.tsx
+++ b/src/features/cabins/__tests__/CreateCabinForm.test.tsx
@@ -6,11 +6,12 @@ import CreateCabinForm from '../CreateCabinForm';
 import { user } from '@/test/fixtures/authentication';
 import { MAX_CABIN_DISCOUNT, MAX_CABIN_IMAGE_SIZE, MIN_CABIN_NAME_LENGTH } from '@/utils/constants';
 import { MockFile } from '@/test/types';
+import { settings } from '@/test/fixtures/settings';
 
 const submitButtonRegex = /create cabin/i;
 
 function setup() {
-	renderWithQueryClient(<CreateCabinForm userId={user.id} />);
+	renderWithQueryClient(<CreateCabinForm userId={user.id} settings={settings} />);
 }
 
 describe('CreateCabinForm', () => {
@@ -99,6 +100,22 @@ describe('CreateCabinForm', () => {
 		await user.click(screen.getByRole('button', { name: submitButtonRegex }));
 
 		const error = screen.getByText(/max capacity must be greater than 0/i);
+
+		expect(error).toBeInTheDocument();
+	});
+
+	it('should show an error message if max capacity value is greater than max guests per booking', async () => {
+		setup();
+		const user = userEvent.setup();
+		const maxCapacityInput = screen.getByLabelText(/max capacity/i);
+
+		await user.clear(maxCapacityInput);
+		await user.type(maxCapacityInput, (settings.max_guests_per_booking + 1).toString());
+		await user.click(screen.getByRole('button', { name: submitButtonRegex }));
+
+		const error = screen.getByText(
+			`Max capacity cannot be greater than ${settings.max_guests_per_booking}`
+		);
 
 		expect(error).toBeInTheDocument();
 	});

--- a/src/features/cabins/__tests__/UpdateCabinForm.test.tsx
+++ b/src/features/cabins/__tests__/UpdateCabinForm.test.tsx
@@ -6,12 +6,13 @@ import UpdateCabinForm from '../UpdateCabinForm';
 import { MAX_CABIN_DISCOUNT, MAX_CABIN_IMAGE_SIZE, MIN_CABIN_NAME_LENGTH } from '@/utils/constants';
 import { MockFile } from '@/test/types';
 import { cabins } from '@/test/fixtures/cabins';
+import { settings } from '@/test/fixtures/settings';
 
 const submitButtonRegex = /update cabin/i;
 
 function setup() {
 	const cabin = cabins[0];
-	renderWithQueryClient(<UpdateCabinForm cabin={cabin} />);
+	renderWithQueryClient(<UpdateCabinForm cabin={cabin} settings={settings} />);
 }
 
 describe('UpdateCabinForm', () => {
@@ -117,6 +118,22 @@ describe('UpdateCabinForm', () => {
 		await user.click(screen.getByRole('button', { name: submitButtonRegex }));
 
 		const error = screen.getByText(/max capacity must be greater than 0/i);
+
+		expect(error).toBeInTheDocument();
+	});
+
+	it('should show an error message if max capacity value is greater than max guests per booking', async () => {
+		setup();
+		const user = userEvent.setup();
+		const maxCapacityInput = screen.getByLabelText(/max capacity/i);
+
+		await user.clear(maxCapacityInput);
+		await user.type(maxCapacityInput, (settings.max_guests_per_booking + 1).toString());
+		await user.click(screen.getByRole('button', { name: submitButtonRegex }));
+
+		const error = screen.getByText(
+			`Max capacity cannot be greater than ${settings.max_guests_per_booking}`
+		);
 
 		expect(error).toBeInTheDocument();
 	});

--- a/src/pages/Cabins.tsx
+++ b/src/pages/Cabins.tsx
@@ -6,10 +6,12 @@ import { useCabins } from '@/features/cabins/hooks/useCabins';
 import CreateCabinForm from '@/features/cabins/CreateCabinForm';
 import { useUser } from '@/features/authentication/hooks/useUser';
 import CabinFilterAndSortControls from '@/features/cabins/CabinFilterAndSortControls';
+import { useSettings } from '@/features/settings/hooks/useSettings';
 
 function Cabins() {
 	const { data: user } = useUser();
-	const { data: cabins, isLoading } = useCabins(user?.id);
+	const { data: cabins, isLoading: isCabinsLoading } = useCabins(user?.id);
+	const { data: settings, isLoading: isSettingsLoading } = useSettings(user?.id);
 
 	return (
 		<>
@@ -17,17 +19,17 @@ function Cabins() {
 				<Heading as="h1">Cabins</Heading>
 				<CabinFilterAndSortControls />
 			</FlexRow>
-			{isLoading ? (
+			{isCabinsLoading || isSettingsLoading ? (
 				<Spinner />
-			) : cabins && cabins.length > 0 ? (
-				<CabinTable cabins={cabins} />
+			) : cabins && cabins.length > 0 && settings ? (
+				<CabinTable cabins={cabins} settings={settings} />
 			) : (
 				<p className="mt-1">No cabins to show</p>
 			)}
 			<Heading as="h2" className="mt-3">
 				Create a cabin
 			</Heading>
-			{user && <CreateCabinForm userId={user.id} />}
+			{user && settings && <CreateCabinForm userId={user.id} settings={settings} />}
 		</>
 	);
 }

--- a/src/pages/__tests__/Cabins.test.tsx
+++ b/src/pages/__tests__/Cabins.test.tsx
@@ -12,6 +12,7 @@ import { CABINS_BASE_URL } from '@/utils/constants';
 import { mockServer } from '@/test/mocks/server';
 import { db } from '@/test/mocks/db';
 import { cabins } from '@/test/fixtures/cabins';
+import { settings } from '@/test/fixtures/settings';
 
 const deleteButtonRegex = /delete/i;
 const updateButtonInCellRegex = /update/i;
@@ -254,12 +255,20 @@ describe('Cabins', () => {
 		const user = userEvent.setup();
 		const imageFile = new File(['test'], 'cabin_image.png', { type: 'image/png' });
 		const createCabinForm = await screen.findByRole('form', { name: /create a cabin/i });
+		const maxCapacityInput = within(createCabinForm).getByLabelText(/max capacity/i);
+		const discountInput = within(createCabinForm).getByLabelText(/discount/i);
 
 		await user.type(within(createCabinForm).getByLabelText(/name/i), 'Test name');
 		await user.type(within(createCabinForm).getByLabelText(/description/i), 'Test description');
-		await user.type(within(createCabinForm).getByLabelText(/max capacity/i), '6');
+
+		await user.clear(maxCapacityInput);
+		await user.type(maxCapacityInput, (settings.max_guests_per_booking - 2).toString());
+
 		await user.type(within(createCabinForm).getByLabelText(/price/i), '600');
-		await user.type(within(createCabinForm).getByLabelText(/discount/i), '20');
+
+		await user.clear(discountInput);
+		await user.type(discountInput, '20');
+
 		await user.upload(within(createCabinForm).getByLabelText(/image/i), imageFile);
 		await user.click(within(createCabinForm).getByRole('button', { name: /create cabin/i }));
 


### PR DESCRIPTION
With this change, max capacity field in create and update cabin forms cannot be greater than `Max guests per booking` setting.