### PR TITLE
Implement booking delete functionality

### DIFF
--- a/src/features/bookings/BookingDetails.tsx
+++ b/src/features/bookings/BookingDetails.tsx
@@ -12,6 +12,9 @@ import BookingPaymentSummary from './BookingPaymentSummary';
 import { Button } from '@/ui/button/Button';
 import { useCheckOutBooking } from './hooks/useCheckOutBooking';
 import SpinnerMini from '@/ui/spinner/SpinnerMini';
+import useModal from '@/hooks/useModal';
+import ConfirmDeleteModal from '@/ui/Modal/ConfirmDeleteModal';
+import { useDeleteBooking } from './hooks/useDeleteBooking';
 
 interface BookingProps {
 	booking: Booking;
@@ -25,92 +28,114 @@ const dateFormatOptions: Intl.DateTimeFormatOptions = {
 };
 
 function BookingDetails({ booking }: BookingProps) {
-	const checkOutBookingMutation = useCheckOutBooking();
-	return (
-		<Container>
-			<Header>
-				<HeadingContainer>
-					<Heading as="h1">Booking #{booking.id}</Heading>
-					<StyledBadge type={bookingStatusToBadgeColorMap[booking.status as BookingStatus]}>
-						{booking.status}
-					</StyledBadge>
-				</HeadingContainer>
-				<LinkButtonIconText to="/bookings">
-					<HiArrowLeft />
-					<span>Bookings</span>
-				</LinkButtonIconText>
-			</Header>
-			<BookingDate className="text-sm">
-				Booked on{' '}
-				<time dateTime={booking.created_at}>
-					{formatDate(booking.created_at, dateFormatOptions)}
-				</time>
-			</BookingDate>
-			<Grid>
-				<div>
-					<BookingDurationDetails>
-						<div>
-							<HiOutlineHomeModern />
-							<p>
-								<span className="fw-semi-bold">{booking.num_nights}</span>{' '}
-								{booking.num_nights > 1 ? 'nights' : 'night'} in{' '}
-								<span className="fw-semi-bold">Cabin {booking.cabin?.name}</span>
-							</p>
-						</div>
-						<div>
-							<p>Check-in</p>
-							<time dateTime={booking.start_date} className="fw-semi-bold">
-								{formatDate(booking.start_date, dateFormatOptions)}
-							</time>
-						</div>
-						<div>
-							<p>Check-out</p>
-							<time dateTime={booking.end_date} className="fw-semi-bold">
-								{formatDate(booking.end_date, dateFormatOptions)}
-							</time>
-						</div>
-					</BookingDurationDetails>
-					{booking.guest && (
-						<Section>
-							<Heading as="h2">Guest Details</Heading>
-							<BookingGuestDetailsTable
-								guestDetails={{ num_guests: booking.num_guests, guest: booking.guest }}
-							/>
-						</Section>
-					)}
-					{booking.observations && (
-						<Observations>
-							<Heading as="h2">Observations & Requests</Heading>
-							<p>{booking.observations}</p>
-						</Observations>
-					)}
-				</div>
+	const {
+		shouldShowModal: shouldShowConfirmDeleteModal,
+		openModal: openConfirmDeleteModal,
+		closeModal: closeConfirmDeleteModal,
+	} = useModal();
 
-				<BookingPaymentSummary
-					paymentInfo={{
-						cabin_price: booking.cabin_price,
-						extra_price: booking.extra_price,
-						total_price: booking.total_price,
-						has_breakfast: booking.has_breakfast,
-						is_paid: booking.is_paid,
-					}}
+	const deleteBookingMutation = useDeleteBooking();
+	const checkOutBookingMutation = useCheckOutBooking();
+
+	return (
+		<>
+			<Container>
+				<Header>
+					<HeadingContainer>
+						<Heading as="h1">Booking #{booking.id}</Heading>
+						<StyledBadge type={bookingStatusToBadgeColorMap[booking.status as BookingStatus]}>
+							{booking.status}
+						</StyledBadge>
+					</HeadingContainer>
+					<LinkButtonIconText to="/bookings">
+						<HiArrowLeft />
+						<span>Bookings</span>
+					</LinkButtonIconText>
+				</Header>
+				<BookingDate className="text-sm">
+					Booked on{' '}
+					<time dateTime={booking.created_at}>
+						{formatDate(booking.created_at, dateFormatOptions)}
+					</time>
+				</BookingDate>
+				<Grid>
+					<div>
+						<BookingDurationDetails>
+							<div>
+								<HiOutlineHomeModern />
+								<p>
+									<span className="fw-semi-bold">{booking.num_nights}</span>{' '}
+									{booking.num_nights > 1 ? 'nights' : 'night'} in{' '}
+									<span className="fw-semi-bold">Cabin {booking.cabin?.name}</span>
+								</p>
+							</div>
+							<div>
+								<p>Check-in</p>
+								<time dateTime={booking.start_date} className="fw-semi-bold">
+									{formatDate(booking.start_date, dateFormatOptions)}
+								</time>
+							</div>
+							<div>
+								<p>Check-out</p>
+								<time dateTime={booking.end_date} className="fw-semi-bold">
+									{formatDate(booking.end_date, dateFormatOptions)}
+								</time>
+							</div>
+						</BookingDurationDetails>
+						{booking.guest && (
+							<Section>
+								<Heading as="h2">Guest Details</Heading>
+								<BookingGuestDetailsTable
+									guestDetails={{ num_guests: booking.num_guests, guest: booking.guest }}
+								/>
+							</Section>
+						)}
+						{booking.observations && (
+							<Observations>
+								<Heading as="h2">Observations & Requests</Heading>
+								<p>{booking.observations}</p>
+							</Observations>
+						)}
+					</div>
+
+					<BookingPaymentSummary
+						paymentInfo={{
+							cabin_price: booking.cabin_price,
+							extra_price: booking.extra_price,
+							total_price: booking.total_price,
+							has_breakfast: booking.has_breakfast,
+							is_paid: booking.is_paid,
+						}}
+					/>
+				</Grid>
+				<ButtonsContainer>
+					{booking.status === 'checked-in' && (
+						<Button
+							onClick={() =>
+								checkOutBookingMutation.mutate({
+									bookingId: booking.id,
+									updatedData: { status: 'checked-out' },
+								})
+							}
+							disabled={checkOutBookingMutation.isLoading}
+						>
+							{checkOutBookingMutation.isLoading ? <SpinnerMini /> : 'Check Out'}
+						</Button>
+					)}
+					<Button $variant="danger" onClick={openConfirmDeleteModal}>
+						Delete
+					</Button>
+				</ButtonsContainer>
+			</Container>
+			{shouldShowConfirmDeleteModal && (
+				<ConfirmDeleteModal
+					resourceName={`booking ${booking.id}`}
+					onConfirmDelete={() => deleteBookingMutation.mutate(booking.id)}
+					onCloseModal={closeConfirmDeleteModal}
+					isDeleting={deleteBookingMutation.isLoading}
 				/>
-			</Grid>
-			{booking.status === 'checked-in' && (
-				<Button
-					className="mt-3"
-					onClick={() =>
-						checkOutBookingMutation.mutate({
-							bookingId: booking.id,
-							updatedData: { status: 'checked-out' },
-						})
-					}
-					disabled={checkOutBookingMutation.isLoading}
-				>
-					{checkOutBookingMutation.isLoading ? <SpinnerMini /> : 'Check Out'}
-				</Button>
 			)}
-		</Container>
+		</>
 	);
 }
 
@@ -181,4 +206,10 @@ const Observations = styled(Section)`
 	p {
 		max-width: 75ch;
 	}
+`;
+
+const ButtonsContainer = styled.div`
+	margin-top: 3rem;
+	display: flex;
+	gap: 10px;
 `;

--- a/src/features/bookings/BookingRow.tsx
+++ b/src/features/bookings/BookingRow.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { HiArrowUpOnSquare, HiEye } from 'react-icons/hi2';
+import { HiArrowUpOnSquare, HiEye, HiOutlineTrash } from 'react-icons/hi2';
 
 import { Booking, BookingStatus } from '@/types/bookings';
 import Table from '@/ui/Table';
@@ -11,9 +11,10 @@ import { useCheckOutBooking } from './hooks/useCheckOutBooking';
 
 interface BookingRowProps {
 	booking: Booking;
+	onClickDelete: (booking: Booking) => void;
 }
 
-function BookingRow({ booking }: BookingRowProps) {
+function BookingRow({ booking, onClickDelete }: BookingRowProps) {
 	const { id, cabin, guest, start_date, end_date, num_nights, total_price, status } = booking;
 	const checkOutBookingMutation = useCheckOutBooking();
 
@@ -56,6 +57,15 @@ function BookingRow({ booking }: BookingRowProps) {
 							<span>Check out</span>
 						</ButtonIconText>
 					)}
+					<ButtonIconText
+						type="button"
+						aria-haspopup="dialog"
+						$variant="danger"
+						onClick={() => onClickDelete(booking)}
+					>
+						<HiOutlineTrash />
+						<span>Delete</span>
+					</ButtonIconText>
 				</ActionButtonsContainer>
 			</Table.Cell>
 		</Table.Row>
@@ -71,5 +81,7 @@ const DarkNumericTextCell = styled(Table.Cell)`
 
 const ActionButtonsContainer = styled.div`
 	display: flex;
-	gap: 12px;
+	flex-direction: column;
+	flex-wrap: wrap;
+	gap: 8px;
 `;

--- a/src/features/bookings/BookingTable.tsx
+++ b/src/features/bookings/BookingTable.tsx
@@ -1,32 +1,78 @@
+import { useState } from 'react';
+
 import { Booking } from '@/types/bookings';
 import Table from '@/ui/Table';
 import BookingRow from './BookingRow';
+import useModal from '@/hooks/useModal';
+import { useDeleteBooking } from './hooks/useDeleteBooking';
+import ConfirmDeleteModal from '@/ui/Modal/ConfirmDeleteModal';
 
 interface BookingTableProps {
 	bookings: Booking[];
 }
 
 function BookingTable({ bookings }: BookingTableProps) {
+	const [selectedBooking, setSelectedBooking] = useState<null | Booking>(null);
+
+	const deleteBookingMutation = useDeleteBooking();
+
+	const {
+		shouldShowModal: shouldShowConfirmDeleteModal,
+		openModal: openConfirmDeleteModal,
+		closeModal: closeConfirmDeleteModal,
+	} = useModal();
+
+	function showConfirmDeleteModalForSelectedBooking(booking: Booking) {
+		setSelectedBooking(booking);
+		openConfirmDeleteModal();
+	}
+
+	function closeConfirmDeleteModalForSelectedBooking() {
+		setSelectedBooking(null);
+		closeConfirmDeleteModal();
+	}
+
+	function deleteSelectedBooking() {
+		if (selectedBooking) {
+			deleteBookingMutation.mutate(selectedBooking.id);
+			closeConfirmDeleteModalForSelectedBooking();
+		}
+	}
+
 	return (
-		<Table id="bookingTable" caption="Bookings">
-			<Table.Head>
-				<Table.Row>
-					<Table.HeaderCell>Cabin</Table.HeaderCell>
-					<Table.HeaderCell>Guest</Table.HeaderCell>
-					<Table.HeaderCell>Duration</Table.HeaderCell>
-					<Table.HeaderCell>Status</Table.HeaderCell>
-					<Table.HeaderCell>Price</Table.HeaderCell>
-					<Table.HeaderCell>
-						<span className="sr-only">Actions</span>
-					</Table.HeaderCell>
-				</Table.Row>
-			</Table.Head>
-			<Table.Body>
-				{bookings.map(booking => (
-					<BookingRow key={booking.id} booking={booking} />
-				))}
-			</Table.Body>
-		</Table>
+		<>
+			<Table id="bookingTable" caption="Bookings">
+				<Table.Head>
+					<Table.Row>
+						<Table.HeaderCell>Cabin</Table.HeaderCell>
+						<Table.HeaderCell>Guest</Table.HeaderCell>
+						<Table.HeaderCell>Duration</Table.HeaderCell>
+						<Table.HeaderCell>Status</Table.HeaderCell>
+						<Table.HeaderCell>Price</Table.HeaderCell>
+						<Table.HeaderCell>
+							<span className="sr-only">Actions</span>
+						</Table.HeaderCell>
+					</Table.Row>
+				</Table.Head>
+				<Table.Body>
+					{bookings.map(booking => (
+						<BookingRow
+							key={booking.id}
+							booking={booking}
+							onClickDelete={showConfirmDeleteModalForSelectedBooking}
+						/>
+					))}
+				</Table.Body>
+			</Table>
+			{selectedBooking && shouldShowConfirmDeleteModal && (
+				<ConfirmDeleteModal
+					resourceName={`booking ${selectedBooking.id}`}
+					onConfirmDelete={deleteSelectedBooking}
+					onCloseModal={closeConfirmDeleteModalForSelectedBooking}
+					isDeleting={deleteBookingMutation.isLoading}
+				/>
+			)}
+		</>
 	);
 }
 

--- a/src/features/bookings/__tests__/BookingRow.test.tsx
+++ b/src/features/bookings/__tests__/BookingRow.test.tsx
@@ -1,22 +1,29 @@
 import { MemoryRouter } from 'react-router-dom';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { renderWithQueryClient } from '@/test/utils';
 import BookingRow from '../BookingRow';
 import { Booking } from '@/types/bookings';
 import { bookings } from '@/test/fixtures/bookings';
 
+const mockOnClickDelete = vi.fn();
+
 function setup(booking: Booking) {
 	renderWithQueryClient(
 		<MemoryRouter>
 			<table>
 				<tbody>
-					<BookingRow booking={booking} />
+					<BookingRow booking={booking} onClickDelete={mockOnClickDelete} />
 				</tbody>
 			</table>
 		</MemoryRouter>
 	);
 }
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe('BookingRow', () => {
 	it('should have a checkout button if the booking status is checked-in', () => {
@@ -29,5 +36,26 @@ describe('BookingRow', () => {
 		setup(bookings[0]);
 		const checkoutButton = screen.queryByRole('button', { name: /check out/i });
 		expect(checkoutButton).not.toBeInTheDocument();
+	});
+
+	it('should have an actions cell with a delete button', () => {
+		setup(bookings[0]);
+
+		const actionsCell = screen.getAllByRole('cell')[5];
+		const deleteButton = within(actionsCell).getByRole('button', { name: /delete/i });
+
+		expect(deleteButton).toBeInTheDocument();
+	});
+
+	it('should call onClickDelete with booking data when delete button is clicked', async () => {
+		const booking = bookings[0];
+		setup(booking);
+		const user = userEvent.setup();
+		const actionsCell = screen.getAllByRole('cell')[5];
+		const deleteButton = within(actionsCell).getByRole('button', { name: /delete/i });
+
+		await user.click(deleteButton);
+
+		expect(mockOnClickDelete).toHaveBeenCalledWith(booking);
 	});
 });

--- a/src/features/bookings/hooks/useDeleteBooking.ts
+++ b/src/features/bookings/hooks/useDeleteBooking.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+
+import { deleteBooking } from '@/services/apiBookings';
+import { BOOKINGS_QUERY_KEY } from '@/utils/constants';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export function useDeleteBooking() {
+	const location = useLocation();
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: deleteBooking,
+		onSuccess: () => {
+			toast.success('Booking deleted successfully!');
+			queryClient.invalidateQueries({ queryKey: [BOOKINGS_QUERY_KEY] });
+			if (location.pathname.includes('bookings/')) {
+				setTimeout(() => {
+					navigate('/bookings', { replace: true });
+				}, 1000);
+			}
+		},
+		onError: (error: Error) => toast.error(error.message),
+	});
+}

--- a/src/services/apiBookings.ts
+++ b/src/services/apiBookings.ts
@@ -104,3 +104,12 @@ export async function updateBooking({
 
 	return data;
 }
+
+export async function deleteBooking(id: number) {
+	const { error } = await supabase.from('booking').delete().eq('id', id);
+
+	if (error) {
+		console.error(error);
+		throw new Error('Booking could not be deleted');
+	}
+}

--- a/src/test/mocks/domains/bookings.ts
+++ b/src/test/mocks/domains/bookings.ts
@@ -96,4 +96,9 @@ export const bookingHandlers = [
 		const updatedBooking = db.booking.update({ where: { id: { equals: bookingId } }, data });
 		return res(ctx.json(updatedBooking), ctx.status(204));
 	}),
+	rest.delete(BOOKINGS_BASE_URL, (req, res, ctx) => {
+		const bookingId = getIdFromQueryString(req.url);
+		db.booking.delete({ where: { id: { equals: bookingId } } });
+		return res(ctx.status(204));
+	}),
 ];

--- a/supabase/migrations/20240420075654_add_booking_delete_access_for_authenticated_users.sql
+++ b/supabase/migrations/20240420075654_add_booking_delete_access_for_authenticated_users.sql
@@ -1,0 +1,6 @@
+create policy "Enable delete access for matching authenticated users"
+on "public"."booking"
+as permissive
+for delete
+to authenticated
+using ((auth.uid() = user_id));


### PR DESCRIPTION
- Added a delete button (that opens delete confirmation modal) on booking details page and to each booking in the Booking table view
- After deleting a booking from the booking details page, the user will be navigated to the bookings page

Bookings page
![booking_delete_button_on_bookings_page](https://github.com/Ayon95/cozylodge/assets/73725297/85d423e3-c219-44df-b588-63eb4a04e4e3)

Booking Details page
![booking_delete_button_on_booking_details_page](https://github.com/Ayon95/cozylodge/assets/73725297/2d437247-8415-4d5f-abaf-114619c1b9b7)

Delete confirmation modal
![booking_delete_confirmation_modal](https://github.com/Ayon95/cozylodge/assets/73725297/de3f6416-6aea-4e97-820a-d194023142ab)
